### PR TITLE
CP-10260 - add new documentation related to deeplinks

### DIFF
--- a/docs/sdks/android/deeplinks.md
+++ b/docs/sdks/android/deeplinks.md
@@ -83,6 +83,7 @@ import android.os.Bundle;
 import android.util.Log;
 import androidx.appcompat.app.AppCompatActivity;
 import com.cleverpush.CleverPush;
+import java.util.List;
 
 public class MainActivity extends AppCompatActivity {
     

--- a/docs/sdks/android/deeplinks.md
+++ b/docs/sdks/android/deeplinks.md
@@ -3,66 +3,327 @@ id: deeplinks
 title: Deep Links
 ---
 
-Deep Links
---------------------
+## CleverPush Deep Links
 
-1. Navigate to app > AndroidManifest.xml and add the below code to it. As we are creating a deep link for our MainActivity.java file so we have to add this code in the MainActivity part. Comments are added in the code to get to know in more detail.
+CleverPush supports **Dynamic Deeplinks** using Android App Links, which automatically detect whether the app is installed and route users accordingly. If the app is not installed, users are redirected to the Play Store.
 
-2. `AndroidManifest.xml`
-``` xml
-<intent-filter>
-  <action android:name="android.intent.action.VIEW" />
-  <category android:name="android.intent.category.DEFAULT" />
-  <category android:name="android.intent.category.BROWSABLE" />
+### Dashboard Configuration
 
-  <!-- on below line we are specifying the host name and the scheme type in add your App name -->
-   <data
-        android:host="https://cleverpush.com"
-        android:scheme="cleverpush" />
-</intent-filter>
-  
-<!-- below is the same filter as above just the scheme is changed to your app name -->
-<intent-filter>
-  <action android:name="android.intent.action.VIEW" />
-  <category android:name="android.intent.category.DEFAULT" />
-  <category android:name="android.intent.category.BROWSABLE" />
-<!-- here the host must be customer's website -->
-  <data
-    android:host="www.cleverpush.com"
-    android:scheme="cleverpush" />
-</intent-filter>
+1. **Enable Deep Links in your Channel Settings:**
+   - Navigate to your Channel → Deep Links section
+   - Enable "Create Deep Links"
+   - Enter a custom subdomain (e.g., `myapp` for `myapp.clpsh.com`)
+   - Save the settings
+
+2. **Create Deep Links:**
+   - Click "Create Deep Link" to create new deep links
+   - Deep links will be automatically generated with the format: `https://{subdomain}.clpsh.com/{path}`
+
+### Android App Links Setup
+
+Android App Links use HTTP/HTTPS URLs that open directly in your app, providing a seamless user experience without disambiguation dialogs.
+
+#### Step 1: Configure App Links in AndroidManifest.xml
+
+Add intent filters to your `MainActivity` (or the activity that should handle deep links) in `AndroidManifest.xml`:
+
+```xml
+<activity
+    android:name=".MainActivity"
+    android:exported="true">
+    
+    <!-- Other intent filters -->
+    
+    <!-- CleverPush Dynamic Deeplink - App Links -->
+    <intent-filter android:autoVerify="true">
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        
+        <!-- Replace {subdomain} with your configured subdomain -->
+        <data
+            android:scheme="https"
+            android:host="{subdomain}.clpsh.com" />
+        
+        <!-- Include tracking subdomain if configured -->
+        <data
+            android:scheme="https"
+            android:host="go.{subdomain}.clpsh.com" />
+    </intent-filter>
+    
+</activity>
 ```
 
-3. Go to your `MainActivity.java` file and refer to the following code. Comments are added inside the code to understand the code in more detail.
+**Example:**
+If your subdomain is `myapp`, use:
+```xml
+<data
+    android:scheme="https"
+    android:host="myapp.clpsh.com" />
+
+<data
+    android:scheme="https"
+    android:host="go.myapp.clpsh.com" />
+```
+
+> **Important:** Make sure to replace `{subdomain}` with your actual subdomain configured in the CleverPush dashboard.
+
+#### Step 2: Handle Deep Links in Your Activity
+
+In your `MainActivity.java` (or Kotlin equivalent), handle the incoming deep link:
 
 <!--DOCUSAURUS_CODE_TABS-->
 
 <!--Java-->
 
-``` java
+```java
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.util.Log;
+import androidx.appcompat.app.AppCompatActivity;
+import com.cleverpush.CleverPush;
+
 public class MainActivity extends AppCompatActivity {
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    setContentView(R.layout.activity_main);
-      
-    // getting the data from our intent in our uri.
-    Uri uri = getIntent().getData();
     
-    // checking if the uri is null or not.
-    if (uri != null) {
-      // if the uri is not null then we are getting the
-      // path segments and storing it in list.
-      List<String> parameters = uri.getPathSegments();
-      
-      // after that we are extracting string from that parameters.
-      String param = parameters.get(parameters.size() - 1);
-      
-      // You can check in our Logcat in your param parameter Log.
-      Log.e("param", param);
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+        
+        // Initialize CleverPush
+        CleverPush.getInstance(this).init("YOUR_CHANNEL_ID");
+        
+        // Handle deep link from intent
+        handleDeepLink(getIntent());
     }
-  }
+    
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        handleDeepLink(intent);
+    }
+    
+    private void handleDeepLink(Intent intent) {
+        Uri data = intent.getData();
+        if (data != null) {
+            // Process the deep link URL
+            String scheme = data.getScheme();
+            String host = data.getHost();
+            String path = data.getPath();
+            String query = data.getQuery();
+            
+            Log.d("DeepLink", "Scheme: " + scheme);
+            Log.d("DeepLink", "Host: " + host);
+            Log.d("DeepLink", "Path: " + path);
+            Log.d("DeepLink", "Query: " + query);
+            
+            // Add your custom navigation/routing logic here
+            // Example: Navigate to a specific screen based on the URL path
+            
+            // Example: Extract path segments
+            List<String> pathSegments = data.getPathSegments();
+            if (pathSegments != null && !pathSegments.isEmpty()) {
+                String firstSegment = pathSegments.get(0);
+                // Navigate based on the path segment
+            }
+        }
+    }
+}
+```
+
+<!--Kotlin-->
+
+```kotlin
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.util.Log
+import androidx.appcompat.app.AppCompatActivity
+import com.cleverpush.CleverPush
+
+class MainActivity : AppCompatActivity() {
+    
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+        
+        // Initialize CleverPush
+        CleverPush.getInstance(this).init("YOUR_CHANNEL_ID")
+        
+        // Handle deep link from intent
+        handleDeepLink(intent)
+    }
+    
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        handleDeepLink(intent)
+    }
+    
+    private fun handleDeepLink(intent: Intent) {
+        val data: Uri? = intent.data
+        if (data != null) {
+            // Process the deep link URL
+            val scheme = data.scheme
+            val host = data.host
+            val path = data.path
+            val query = data.query
+            
+            Log.d("DeepLink", "Scheme: $scheme")
+            Log.d("DeepLink", "Host: $host")
+            Log.d("DeepLink", "Path: $path")
+            Log.d("DeepLink", "Query: $query")
+            
+            // Add your custom navigation/routing logic here
+            // Example: Navigate to a specific screen based on the URL path
+            
+            // Example: Extract path segments
+            val pathSegments = data.pathSegments
+            if (!pathSegments.isNullOrEmpty()) {
+                val firstSegment = pathSegments[0]
+                // Navigate based on the path segment
+            }
+        }
+    }
 }
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->
+
+#### Step 3: Digital Asset Links Verification
+
+Android requires verification that your app is authorized to handle links for your domain. CleverPush automatically handles this verification by serving the required `assetlinks.json` file.
+
+The verification happens automatically when:
+- Your app is installed
+- Your app receives a deep link intent
+
+You can manually verify the asset links are working by:
+1. Using the Android Debug Bridge: `adb shell pm verify-app-links --re-verify <package-name>`
+2. Checking in Android Settings → Apps → Your App → Open by default → Verified links
+
+#### Step 4: Handle Deep Links from Push Notifications
+
+When `autoHandleDeepLink` is enabled in your CleverPush channel settings, the SDK automatically handles deep links from push notifications. You can enable this in:
+- Channel Settings → Android → Deep Links → "Automatically handle deep link via system"
+
+If you need custom handling for notification deep links, use the `NotificationOpenedListener`:
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--Java-->
+
+```java
+CleverPush.getInstance(this).init(
+    "YOUR_CHANNEL_ID",
+    null, // NotificationReceivedListener (optional)
+    new NotificationOpenedListener() {
+        @Override
+        public void notificationOpened(NotificationOpenedResult result) {
+            if (result != null && result.getNotification() != null) {
+                String url = result.getNotification().getUrl();
+                if (url != null) {
+                    // Handle the deep link URL from notification
+                    Uri deepLinkUri = Uri.parse(url);
+                    handleDeepLinkUrl(deepLinkUri);
+                }
+            }
+        }
+    },
+    null  // SubscribedListener (optional)
+);
+```
+
+<!--Kotlin-->
+
+```kotlin
+CleverPush.getInstance(this).init(
+    "YOUR_CHANNEL_ID",
+    null, // NotificationReceivedListener (optional)
+    NotificationOpenedListener { result ->
+        if (result?.notification?.url != null) {
+            val url = result.notification.url
+            // Handle the deep link URL from notification
+            val deepLinkUri = Uri.parse(url)
+            handleDeepLinkUrl(deepLinkUri)
+        }
+    },
+    null  // SubscribedListener (optional)
+)
+```
+
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+### Legacy Custom URL Schemes (Deprecated)
+
+> **Note:** Custom URL schemes are deprecated in favor of App Links. We recommend using Dynamic Deeplinks with App Links for better compatibility.
+
+If you still need to use custom URL schemes for legacy reasons, you can add them alongside App Links:
+
+```xml
+<activity
+    android:name=".MainActivity"
+    android:exported="true">
+    
+    <!-- App Links (recommended) -->
+    <intent-filter android:autoVerify="true">
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data
+            android:scheme="https"
+            android:host="{subdomain}.clpsh.com" />
+    </intent-filter>
+    
+    <!-- Legacy custom URL scheme (deprecated) -->
+    <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data
+            android:scheme="myapp"
+            android:host="*" />
+    </intent-filter>
+    
+</activity>
+```
+
+### Testing Deep Links
+
+1. **Test App Links using ADB:**
+   ```bash
+   adb shell am start -a android.intent.action.VIEW -d "https://{subdomain}.clpsh.com/{path}"
+   ```
+
+2. **Test from Browser:**
+   - Create a simple HTML page with a link: `<a href="https://{subdomain}.clpsh.com/{path}">Open App</a>`
+   - Open the page in Chrome on your Android device
+   - Tapping the link should open your app directly
+
+3. **Verify App Links:**
+   ```bash
+   adb shell pm get-app-links <your-package-name>
+   ```
+
+4. **Debug App Links:**
+   ```bash
+   adb shell pm set-app-links --package <your-package-name> 0 all
+   ```
+
+### Troubleshooting
+
+- **Links open in browser instead of app:**
+  - Verify `android:autoVerify="true"` is set in your intent-filter
+  - Check that your app's package name matches what's configured in CleverPush
+  - Ensure the Digital Asset Links verification passed
+
+- **Verification failed:**
+  - Check that CleverPush is serving the assetlinks.json correctly
+  - Verify your subdomain matches exactly (case-sensitive)
+  - Clear app data and reinstall the app
+
+- **Multiple apps handling the same link:**
+  - Ensure only your app has the correct intent-filter configured
+  - Use App Links (with autoVerify) instead of custom URL schemes to avoid disambiguation dialogs

--- a/docs/sdks/ios/deeplinks.md
+++ b/docs/sdks/ios/deeplinks.md
@@ -5,34 +5,207 @@ title: Deep Links
 
 ## CleverPush Deep Links
 
-1. Open the Project in Xcode.
-2. Select the project's main target.
-3. Select the info tab.
-4. Select the url type.
-5. Select the url scheme and enter the url scheme (Example :- cleverpush)
-6. Go to the button of any view controller from where we need to share the url to another user 
+CleverPush supports **Dynamic Deeplinks** using Universal Links, which automatically detect whether the app is installed and route users accordingly. If the app is not installed, users are redirected to the App Store.
+
+### Dashboard Configuration
+
+1. **Enable Deep Links in your Channel Settings:**
+   - Navigate to your Channel → Deep Links section
+   - Enable "Create Deep Links"
+   - Enter a custom subdomain (e.g., `myapp` for `myapp.clpsh.com`)
+   - Save the settings
+
+2. **Create Deep Links:**
+   - Click "Create Deep Link" to create new deep links
+   - Deep links will be automatically generated with the format: `https://{subdomain}.clpsh.com/{path}`
+
+### iOS Universal Links Setup
+
+Universal Links allow your app to handle web links directly, providing a seamless user experience. CleverPush automatically generates the `apple-app-site-association` file for your subdomain.
+
+#### Step 1: Configure Universal Links in Xcode
+
+1. Open your project in Xcode
+2. Select your app's main target
+3. Go to the **Signing & Capabilities** tab
+4. Click **+ Capability** and add **Associated Domains**
+5. Add your CleverPush deeplink domain:
+   - For production: `applinks:{subdomain}.clpsh.com`
+   - For tracking domains: `applinks:go.{subdomain}.clpsh.com` (if configured)
+   - Replace `{subdomain}` with your configured subdomain from the CleverPush dashboard
+
+**Example:**
+If your subdomain is `myapp`, add:
+```
+applinks:myapp.clpsh.com
+applinks:go.myapp.clpsh.com
+```
+
+#### Step 2: Handle Universal Links in Your App
+
+The CleverPush SDK can automatically handle deep links if enabled in your channel settings (`autoHandleDeepLink`). 
+
+However, if you need custom handling, implement the following in your `AppDelegate.swift`:
 
 <!--DOCUSAURUS_CODE_TABS-->
 
 <!--Swift-->
 
 ```swift
-@IBAction func btnHandlerShareURL(_ sender: Any) {
-    // From here user can share their own url to another user using the share activity (Example :- let path = "cleverpush://") 
-    let path = "url://"
-    let textToShare = [ path ]
-    let activityViewController = UIActivityViewController(activityItems: textToShare, applicationActivities: nil)
-    activityViewController.popoverPresentationController?.sourceView = self.view
-    activityViewController.excludedActivityTypes = [ UIActivity.ActivityType.airDrop, UIActivity.ActivityType.postToFacebook ]
-    self.present(activityViewController, animated: true, completion: nil)
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
     
+    func application(_ application: UIApplication,
+                     continue userActivity: NSUserActivity,
+                     restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
+        // Handle Universal Links
+        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+              let url = userActivity.webpageURL else {
+            return false
+        }
+        
+        // Process the deep link URL
+        print("Received Universal Link: \(url)")
+        
+        // Add your custom navigation/routing logic here
+        // Example: Navigate to a specific screen based on the URL path
+        
+        return true
+    }
 }
+```
+
+<!--Objective-C-->
+
+```objective-c
+#import <UIKit/UIKit.h>
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application
+continueUserActivity:(NSUserActivity *)userActivity
+ restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler {
+    // Handle Universal Links
+    if (![userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb] || !userActivity.webpageURL) {
+        return NO;
+    }
+    
+    NSURL *url = userActivity.webpageURL;
+    NSLog(@"Received Universal Link: %@", url);
+    
+    // Add your custom navigation/routing logic here
+    // Example: Navigate to a specific screen based on the URL path
+    
+    return YES;
+}
+
+@end
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
+#### Step 3: Handle Universal Links with SceneDelegate (iOS 13+)
 
-7. Add the following code in your AppDelegate.swift file
+If you're using SceneDelegate, implement the following:
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--Swift-->
+
+```swift
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    
+    func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        // Handle Universal Links
+        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+              let url = userActivity.webpageURL else {
+            return
+        }
+        
+        // Process the deep link URL
+        print("Received Universal Link: \(url)")
+        
+        // Add your custom navigation/routing logic here
+    }
+}
+```
+
+<!--Objective-C-->
+
+```objective-c
+#import <UIKit/UIKit.h>
+
+@implementation SceneDelegate
+
+- (void)scene:(UIScene *)scene continueUserActivity:(NSUserActivity *)userActivity {
+    // Handle Universal Links
+    if (![userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb] || !userActivity.webpageURL) {
+        return;
+    }
+    
+    NSURL *url = userActivity.webpageURL;
+    NSLog(@"Received Universal Link: %@", url);
+    
+    // Add your custom navigation/routing logic here
+}
+
+@end
+```
+
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+#### Step 4: Configure SDK for Universal Links (Optional)
+
+If you need to handle Universal Links differently or for legacy compatibility, you can configure which domains should be handled as Universal Links:
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--Swift-->
+
+```swift
+import CleverPush
+
+// In your AppDelegate didFinishLaunchingWithOptions:
+let domains = ["myapp.clpsh.com", "go.myapp.clpsh.com"]
+CleverPush.setHandleUniversalLinksInApp(forDomains: domains)
+```
+
+<!--Objective-C-->
+
+```objective-c
+#import <CleverPush/CleverPush.h>
+
+// In your AppDelegate didFinishLaunchingWithOptions:
+NSArray<NSString *> *domains = @[@"myapp.clpsh.com", @"go.myapp.clpsh.com"];
+[CleverPush setHandleUniversalLinksInAppForDomains:domains];
+```
+
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+### Automatic Deep Link Handling
+
+When `autoHandleDeepLink` is enabled in your CleverPush channel settings, the SDK automatically handles deep links from push notifications. This setting applies to both Universal Links and custom URL schemes.
+
+You can enable this in:
+- Channel Settings → iOS → Deep Links → "Automatically handle deep link via system"
+
+### Legacy Custom URL Schemes (Deprecated)
+
+> **Note:** Custom URL schemes are deprecated in favor of Universal Links. We recommend using Dynamic Deeplinks with Universal Links for better compatibility and to fix Safari popup issues.
+
+If you still need to use custom URL schemes for legacy reasons:
+
+1. Configure URL Types in Xcode:
+   - Select your project's main target
+   - Go to the **Info** tab
+   - Under **URL Types**, add a new URL Type
+   - Enter your URL scheme (e.g., `myapp`)
+
+2. Handle custom URL scheme in AppDelegate:
 
 <!--DOCUSAURUS_CODE_TABS-->
 
@@ -40,15 +213,45 @@ title: Deep Links
 
 ```swift
 func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-    // From here we can check that url contains cleverpush or not?
-    if url.scheme == "cleverpush" {
-        let ab = UIStoryboard(name: "Main", bundle: nil)
-        let vc = ab.instantiateViewController(withIdentifier: "ViewController") as! ViewController
-        window?.rootViewController = vc
+    // Handle custom URL scheme
+    if url.scheme == "myapp" {
+        // Process the deep link
+        print("Received custom URL scheme: \(url)")
+        // Add your navigation logic here
+        return true
     }
+    return false
+}
+```
 
-    return true
+<!--Objective-C-->
+
+```objective-c
+- (BOOL)application:(UIApplication *)app
+            openURL:(NSURL *)url
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+    // Handle custom URL scheme
+    if ([url.scheme isEqualToString:@"myapp"]) {
+        // Process the deep link
+        NSLog(@"Received custom URL scheme: %@", url);
+        // Add your navigation logic here
+        return YES;
+    }
+    return NO;
 }
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->
+
+### Testing Deep Links
+
+1. **Test Universal Links:**
+   - Use the Long Press context menu on a link (on device)
+   - Or use the Notes app to create a link and tap it
+   - Universal Links work best when tested on a real device
+
+2. **Verify Configuration:**
+   - Check that your Associated Domains are correctly configured in Xcode
+   - Ensure your subdomain matches the one configured in CleverPush dashboard
+   - The `apple-app-site-association` file is automatically generated by CleverPush at:
+    `https://{subdomain}.clpsh.com/.well-known/apple-app-site-association`


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds new deep link documentation for Android App Links and iOS Universal Links, covering dashboard setup, app configuration, SDK handling, testing, and troubleshooting. Deprecates custom URL schemes and addresses Linear CP-10260.

- **Migration**
  - Enable Deep Links in the CleverPush dashboard and set a subdomain (e.g., myapp.clpsh.com).
  - Android: Add https intent-filters with your subdomain (and optional go.{subdomain}) in AndroidManifest and handle deep link intents.
  - iOS: Add Associated Domains (applinks:{subdomain} and optional go.{subdomain}) and handle Universal Links in AppDelegate/SceneDelegate.

<sup>Written for commit 9c645403b194b49c838d082a4f05511a1f5917bf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



